### PR TITLE
fix: Remove `Recorder` parameter as it was causing issues in Docker

### DIFF
--- a/pkg/egress/auth.go
+++ b/pkg/egress/auth.go
@@ -25,7 +25,6 @@ func (p *authProvider) buildEmptyToken(room string, identity string) (string, er
 		CanPublishData: &f,
 		CanSubscribe:   &f,
 		Hidden:         true,
-		Recorder:       true,
 	}
 	return at.
 		AddGrant(grant).


### PR DESCRIPTION
- The problem was when the container is started in Docker, the first recording always yields 32 bytes for a VP8 video, which is actually the size of the headers. No matter how long the recording is, it will not write to the file.
- The solution, after some lengthy experimentation, is to remove the `Recorder` line. We should not even touch this parameter in the first place as we're not using github.com/livekit/livekit-recorder