### PR TITLE
fix: Change to subscriber token but without auto subscribe

### DIFF
--- a/pkg/recording/auth.go
+++ b/pkg/recording/auth.go
@@ -18,13 +18,15 @@ func createAuthProvider(key string, secret string) *authProvider {
 func (p *authProvider) buildEmptyToken(room string, identity string) (string, error) {
 	at := auth.NewAccessToken(p.APIKey, p.APISecret)
 	f := false
+	t := true
 	grant := &auth.VideoGrant{
 		Room:           room,
 		RoomJoin:       true,
 		CanPublish:     &f,
 		CanPublishData: &f,
-		CanSubscribe:   &f,
+		CanSubscribe:   &t,
 		Hidden:         true,
+		Recorder:       true,
 	}
 	return at.
 		AddGrant(grant).


### PR DESCRIPTION
- We can remove the RTCP Feedback to the server with this approach as the server is aware of the recorder's subscription now