### PR TITLE
More fixes + revert to auto-suggest media profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /build/
 RUN go mod download
 
 # Finally, build the Go app
+RUN apk add git
 RUN go build -o livekit-recorder .
 # ----------
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,28 @@
+# Disclaimer
+
+This project has been stable for our use at Cloud Ground Control. However, we will be moving to `livekit-egress` when it comes out. The good news is I will be contributing to that project, so for any suggestions, you can file it here or talk to us on Slack!
+
 # LiveKit Recorder
 
 Service to record each participant in LiveKit room without transcoding. Prioritises minimum resource consumption for scalability. For composite recording (multiple participants in one layout), check out https://github.com/livekit/livekit-recorder.
 
-## TODO
+## Features
 
 - [x] Single track recording
-- [x] Add Dockerfile
-- [x] Upload to S3
-- [x] Mux video + audio tracks
+- [x] Track composite recording (video + audio)
 - [x] Docker support
-- [] Custom file name
-- [] Job queue
+- [x] Upload to S3
+- [x] Structured logging
+- [ ] Custom file name
+- [ ] Job queue
 
 ## Motivation
 
-The original https://github.com/livekit/livekit-recorder was intended mainly for compositing participants, but consumes significant resources as it runs a Chrome instance. We only want to record each participant, and running the composite recorder per participant was too expensive to scale. Our solution is to record each RTP track via LiveKit's `server-sdk-go` without using Chrome.
+The original https://github.com/livekit/livekit-recorder was intended mainly for compositing participants, but consumes significant resources due to Chrome. We only want to record each participant, and that recorder was too expensive to scale. Our solution is to record each RTP stream via LiveKit's `server-sdk-go`.
 
 ## How it works
 
-The project has a service which is responsible for managing <strong>recordbots</strong>. The bots do not subscribe to all the participants; instead, we need to send a POST request specifying which room and participant to record, and the output name. This means we can have multiple bots in the room without duplicated recording, making it scalable through a Load Balancer. To stop the recording, either send a POST request to stop, or disconnect the participant from the room. We then use `ffmpeg` to containerise the output files.
+The project has a service which is responsible for managing <strong>recordbots</strong>. The bots use selective subscription so we can have multiple bots in the room without duplicated recording, making it scalable through a Load Balancer. To stop the recording, either send a POST request to stop, or disconnect the participant from the room. We then use `ffmpeg` to containerise the output files.
 
 ## Prerequisite
 
@@ -33,7 +37,7 @@ LIVEKIT_URL=ws://... \
 LIVEKIT_API_KEY=... \
 LIVEKIT_API_SECRET=... \
 APP_PORT=8000 \
-APP_DEBUG=true \
+LOG_LEVEL=debug \
 go run main.go
 ```
 
@@ -45,7 +49,6 @@ Next, create a POST request to `/recordings/start` with the body:
 {
     "room": "my-room",
     "participant": "my-participant",
-    "profile": "av / video / audio"
 }
 ```
 
@@ -60,17 +63,45 @@ After recording for some time, to stop, either disconnect from the room, or crea
 
 You should have a file in the `recordings/` folder.
 
-## S3 upload
+## Triggers
 
-To enable S3 upload, make sure to set the following variables:
+There are 2 ways to perform recording.
 
-```
-S3_REGION=
-S3_BUCKET=
-S3_DIRECTORY=
-```
+#### Manual
 
-The variable `S3_DIRECTORY` is optional. For our use case, our bucket stores recordings for different environments. For `S3_DIRECTORY=livekit` and a file named `my-file.mp4`, the resulting file will be saved as `livekit/my-file.mp4` on S3.
+Use POST endpoints `/recordings/start` and `/recordings/stop` with the payload specified in quickstart.
+
+#### Webhooks
+
+The endpoint `/recordings/webhooks` will readily receive LiveKit's webhooks. Recording will start when receiving the event `participant_joined` and stop automatically on the event `participant_left`.
+
+## Environment Variables
+
+#### Required
+
+| Flag               | Description                                        |
+| ------------------ | -------------------------------------------------- |
+| APP_PORT           | Exposed port for the service                       |
+| LOG_LEVEL          | One of `debug`, `info`, `warn`, `error`            |
+| LIVEKIT_URL        | Use `ws` format, will convert to `http` internally |
+| LIVEKIT_API_KEY    | Your LiveKit API key                               |
+| LIVEKIT_API_SECRET | Your LiveKit API secret                            |
+
+#### S3 upload
+
+To enable S3 upload, make sure to set the following variables. Both region and bucket variables are required to create an S3 uploader.
+
+| Flag         | Description          |
+| ------------ | -------------------- |
+| S3_REGION    | AWS region           |
+| S3_BUCKET    | Name of S3 bucket    |
+| S3_DIRECTORY | Optional, read below |
+
+For our use case, we have one bucket for different environments. If we specify `S3_DIRECTORY=livekit` and a file named `my-file.mp4`, the resulting file will be saved as `livekit/my-file.mp4` on S3.
+
+## Deployment
+
+We have shipped a Dockerfile which can be built locally. Unfortunately we don't have plans to have a DockerHub account, so you'll need to clone the repository, build the image, and push to container registry of your choice (ECR, etc.).
 
 ## Issues
 

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/pion/logging v0.2.2 // indirect
 	github.com/pion/mdns v0.0.5 // indirect
 	github.com/pion/randutil v0.1.0 // indirect
-	github.com/pion/rtcp v1.2.9
+	github.com/pion/rtcp v1.2.9 // indirect
 	github.com/pion/sctp v1.8.2 // indirect
 	github.com/pion/sdp/v3 v3.0.4 // indirect
 	github.com/pion/srtp/v2 v2.0.5 // indirect

--- a/pkg/recording/subscription.go
+++ b/pkg/recording/subscription.go
@@ -6,19 +6,6 @@ import (
 	"github.com/livekit/protocol/livekit"
 )
 
-func (s *service) getProfileTracks(req MediaProfile, tracks []*livekit.TrackInfo) []*livekit.TrackInfo {
-	var recordables []*livekit.TrackInfo
-	for _, t := range tracks {
-		if t.Type == livekit.TrackType_VIDEO && (req == MediaVideoOnly || req == MediaMuxedAV) {
-			recordables = append(recordables, t)
-		}
-		if t.Type == livekit.TrackType_AUDIO && (req == MediaAudioOnly || req == MediaMuxedAV) {
-			recordables = append(recordables, t)
-		}
-	}
-	return recordables
-}
-
 type UpdateTrackSubscriptionsRequest struct {
 	Room     string
 	Identity string
@@ -34,60 +21,4 @@ func (s *service) updateTrackSubscriptions(ctx context.Context, req UpdateTrackS
 		Subscribe: req.Subcribe,
 	})
 	return err
-}
-
-func (s *service) RemoveBotSubscriptionCallback(bot string, room string, participant string, req MediaProfile) error {
-	// Get participant info to be able to get the tracks the bot is subscribed to
-	ctx := context.TODO()
-	pi, err := s.lksvc.GetParticipant(ctx, &livekit.RoomParticipantIdentity{
-		Room:     room,
-		Identity: participant,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Get the SIDs that the bot is subscribed to
-	var sids []string
-	for _, r := range s.getProfileTracks(req, pi.Tracks) {
-		sids = append(sids, r.Sid)
-	}
-
-	// Unsubscribe the bot from the participant tracks
-	return s.updateTrackSubscriptions(ctx, UpdateTrackSubscriptionsRequest{
-		Room:     room,
-		Identity: bot,
-		SIDs:     sids,
-		Subcribe: false,
-	})
-}
-
-func (s *service) SuggestMediaProfile(ctx context.Context, room string, identity string) (MediaProfile, error) {
-	pi, err := s.lksvc.GetParticipant(ctx, &livekit.RoomParticipantIdentity{
-		Room:     room,
-		Identity: identity,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	var videoEnabled, audioEnabled bool
-	for _, t := range pi.Tracks {
-		switch t.Type {
-		case livekit.TrackType_VIDEO:
-			videoEnabled = true
-		case livekit.TrackType_AUDIO:
-			audioEnabled = true
-		}
-	}
-
-	if videoEnabled && audioEnabled {
-		return MediaMuxedAV, nil
-	} else if videoEnabled && !audioEnabled {
-		return MediaVideoOnly, nil
-	} else if audioEnabled && !videoEnabled {
-		return MediaAudioOnly, nil
-	}
-
-	return "", ErrUnknownMediaProfile
 }


### PR DESCRIPTION
- In webhooks, checking if participant has at least 1 track is not reliable enough: their state would be JOINED, but not yet ACTIVE. We noticed timing issues where we tried getting participant info when state is JOINED, but turns out the participant does not exist yet. Hence, we should rely on the ACTIVE state.
- When the room is killed by LiveKit after inactivity, the service still stores reference to that outdated room. Subsequent recording requests will use this room and return error. The solution is to listen to webhook event and remove the bot (with that room) when the room has finished
- We now use auto-suggestion of media profile for simpler code; no need to specify the media profile in the HTTP layer
- Remove unused code and verification as we're using auto-suggest